### PR TITLE
Add PasteHandler to perform paste image action on normal paste

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -19,6 +19,7 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <!-- Add your extensions here -->
+    <editorActionHandler action="EditorPaste" implementationClass="img2md.PasteImageHandler" order="first" />
   </extensions>
 
   <actions>

--- a/src/img2md/PasteImageHandler.java
+++ b/src/img2md/PasteImageHandler.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
 import java.awt.*;
 
 public class PasteImageHandler extends EditorActionHandler {
-    private static final Logger LOG = Logger.getInstance("#com.intellij.codeInsight.editorActions.PasteHandler");
+    private static final Logger LOG = Logger.getInstance("img2md.PasteHandler");
     private final EditorActionHandler myOriginalHandler;
 
     public PasteImageHandler(EditorActionHandler originalAction) {

--- a/src/img2md/PasteImageHandler.java
+++ b/src/img2md/PasteImageHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2015-2017 Vladimir Schneider <vladimir.schneider@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+package img2md;
+
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Caret;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler;
+import com.intellij.openapi.editor.ex.EditorEx;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+
+public class PasteImageHandler extends EditorActionHandler {
+    private static final Logger LOG = Logger.getInstance("#com.intellij.codeInsight.editorActions.PasteHandler");
+    private final EditorActionHandler myOriginalHandler;
+
+    public PasteImageHandler(EditorActionHandler originalAction) {
+        myOriginalHandler = originalAction;
+    }
+
+    private AnActionEvent createAnEvent(AnAction action, @NotNull DataContext context) {
+        Presentation presentation = action.getTemplatePresentation().clone();
+        return new AnActionEvent(null, context, ActionPlaces.UNKNOWN, presentation, ActionManager.getInstance(), 0);
+    }
+
+    @Override
+    public void doExecute(final Editor editor, Caret caret, final DataContext dataContext) {
+        if (editor instanceof EditorEx && ((EditorEx) editor).getVirtualFile().getFileType().getName().equals("Markdown")) {
+            Image imageFromClipboard = ImageUtils.getImageFromClipboard();
+            if (imageFromClipboard != null) {
+                assert caret == null : "Invocation of 'paste' operation for specific caret is not supported";
+                PasteImageFromClipboard action = new PasteImageFromClipboard();
+                AnActionEvent event = createAnEvent(action, dataContext);
+                action.actionPerformed(event);
+                return;
+            }
+        }
+
+        if (myOriginalHandler != null) {
+            myOriginalHandler.execute(editor, caret, dataContext);
+        }
+    }
+}


### PR DESCRIPTION
PasteHandler will invoke the PasteImageFromClipboard action if the clipboard contains an image and the file type name is "Markdown"

BTW, I added the functionality to Markdown Navigator it works great. Had to add scaling option because for some reason 2017 has the clipboard image in retina resolution but 2016 versions have it in normal resolution.